### PR TITLE
Div 2308 make em work on all pipelines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,10 @@ task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verificatio
     }
 }
 
+task functional(type: Test, description: 'Runs the functional tests', group: 'Verification') {
+    include "uk.gov.hmcts.reform.emclient.functional/**"
+}
+
 task printVersion {
     doLast {
         print project.version

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "div-em-client-api" {
-  source       = "git@github.com:contino/moj-module-webapp.git?ref=master"
+  source       = "git@github.com:hmcts/moj-module-webapp.git?ref=master"
   product      = "${var.reform_team}-${var.reform_service_name}"
   location     = "${var.location}"
   env          = "${var.env}"


### PR DESCRIPTION
Updated gradle.build to include functional test task as required for CNP
Changed to point to https://github.com/hmcts/moj-module-webapp rather than contino's private URL