### PR TITLE
Restrict CNP capacity to 1 for all non-production-like environments

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,2 +1,3 @@
 vault_env = "preprod"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
+capacity = "2"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,2 +1,3 @@
 vault_env = "preprod"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
+capacity = "2"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -13,6 +13,7 @@ module "div-emca" {
   ilbIp                           = "${var.ilbIp}"
   subscription                    = "${var.subscription}"
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
+  capacity                        = "${var.capacity}"
   is_frontend                     = false
 
   app_settings = {

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,2 +1,3 @@
 vault_env = "prod"
 idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
+capacity = "2"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -25,6 +25,10 @@ variable "reform_team" {
   default = "div"
 }
 
+variable "capacity" {
+  default = "1"
+}
+
 variable "env" {
   type = "string"
 }


### PR DESCRIPTION
# Description

This change means that only `prod`, `aat` and `demo` environments will have their capacity set to 2 instances (i.e. 2 load-balanced apps), to reduce resource utilisation in other environments. Otherwise capacity will be restricted to '1'.

This has been requested for all services across all teams.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This can't be tested locally, but follows the advice outlined on Confluence and the same approach is currently working for div-petitioner-frontend. 


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
