### PR TITLE
DIV-2723: Removed adding bearer to token when we receive it (Don't merge yet)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,9 +121,9 @@ def versions = [
         skyscreamer: '1.2.3',
         sprintBoot: '1.5.12.RELEASE',
         springCloud: '1.2.5.RELEASE',
-        springRetry: '1.2.1.RELEASE',
         springHateoas: '0.23.0.RELEASE',
         springPluginCore: '1.2.0.RELEASE',
+        springRetry: '1.2.1.RELEASE',
         unirestJava: '1.4.9',
         wiremockVersion: '2.8.0'
 ]

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/emclient/IDAMUtils.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/emclient/IDAMUtils.java
@@ -53,7 +53,7 @@ class IDAMUtils {
         }
 
         String token = response.getBody().path("access-token");
-        return "Bearer " + token;
+        return token;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/emclient/idam/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/idam/services/UserService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.emclient.idam.services;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.emclient.idam.api.IdamApiClient;
@@ -8,8 +7,6 @@ import uk.gov.hmcts.reform.emclient.idam.models.UserDetails;
 
 @Component
 public class UserService {
-
-    private static String BEARER = "Bearer";
 
     private final IdamApiClient idamApiClient;
 
@@ -19,10 +16,7 @@ public class UserService {
     }
 
     public UserDetails getUserDetails(String authorisation) {
-        String authToken = StringUtils.containsIgnoreCase(authorisation, BEARER)
-                ? authorisation
-                : String.format("%s %s", BEARER, authorisation);
-        return idamApiClient.retrieveUserDetails(authToken);
+        return idamApiClient.retrieveUserDetails(authorisation);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/emclient/idam/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/idam/UserServiceTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class UserServiceTest {
 
+    private static final String AUTH_TOKEN = "Bearer authTokenValue";
+
     @Mock
     private IdamApiClient idamApiClient;
 
@@ -27,17 +29,15 @@ public class UserServiceTest {
     public void userServiceReturnUserDetails(){
 
         UserDetails userDetails = UserDetails.builder().id("IdOne").build();
-        String authToken = "Bearer authTokenValue";
-        when(idamApiClient.retrieveUserDetails(authToken)).thenReturn(userDetails);
+        when(idamApiClient.retrieveUserDetails(AUTH_TOKEN)).thenReturn(userDetails);
 
-        assertThat(testObj.getUserDetails(authToken)).isEqualTo(userDetails);
+        assertThat(testObj.getUserDetails(AUTH_TOKEN)).isEqualTo(userDetails);
     }
 
     @Test(expected = HttpClientErrorException.class)
     public void userServiceThrowErrorWhenNotAuthorised(){
-        String authToken = "Bearer authTokenValue";
-        when(idamApiClient.retrieveUserDetails(authToken)).thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+        when(idamApiClient.retrieveUserDetails(AUTH_TOKEN)).thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
 
-        testObj.getUserDetails(authToken);
+        testObj.getUserDetails(AUTH_TOKEN);
     }
 }


### PR DESCRIPTION
We currently have a bit of a hack in place where we get the token from pfe, and append "Bearer" to the start of the token, this PR removes that as we have a new fix in PFE that sends "Bearer" as part of the token.

Should be merged after this is merged in
https://github.com/hmcts/div-petitioner-frontend/pull/204

