### PR TITLE
[PREVIEW] Add in Root Controller

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/emclient/application/EvidenceManagementClientApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/application/EvidenceManagementClientApplication.java
@@ -5,12 +5,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
-import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.retry.annotation.EnableRetry;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
@@ -21,9 +19,7 @@ import uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuthHealthIndicator;
 @ComponentScan(basePackages = "uk.gov.hmcts", excludeFilters = {
     @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = ServiceAuthHealthIndicator.class) })
 @EnableAutoConfiguration(exclude = {HypermediaAutoConfiguration.class, ServiceAuthHealthIndicator.class})
-@EnableRetry(proxyTargetClass=true)
 @EnableFeignClients(basePackageClasses = {ServiceAuthorisationApi.class, IdamApiClient.class})
-@EnableCircuitBreaker
 public class EvidenceManagementClientApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/uk/gov/hmcts/reform/emclient/controller/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/controller/RootController.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.emclient.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+/**
+ * Default endpoints per application.
+ */
+@RestController
+@RequestMapping(path = "/")
+public class RootController {
+
+    /**
+     * Root GET endpoint.
+     *
+     * <p>Azure application service has a hidden feature of making requests to root endpoint when
+     * "Always On" is turned on.
+     * This is the endpoint to deal with that and therefore silence the unnecessary 404s as a response code.
+     *
+     * @return Welcome message from the service.
+     */
+    @GetMapping
+    public ResponseEntity<String> welcome() {
+        return ok("Welcome to Divorce Evidence Management Client API");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/emclient/controller/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/controller/RootController.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.emclient.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.http.ResponseEntity.ok;
 

--- a/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.emclient.controller;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
@@ -3,27 +3,20 @@ package uk.gov.hmcts.reform.emclient.controller;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRibbonClientAutoConfiguration;
-import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
 import uk.gov.hmcts.reform.emclient.application.EvidenceManagementClientApplication;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(RootController.class)
-@ImportAutoConfiguration({RibbonAutoConfiguration.class,HttpMessageConvertersAutoConfiguration.class, FeignRibbonClientAutoConfiguration.class, FeignAutoConfiguration.class})
-@ContextConfiguration(classes = EvidenceManagementClientApplication.class)
+@SpringBootTest(classes=EvidenceManagementClientApplication.class)
 @AutoConfigureMockMvc
 public class RootControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/controller/RootControllerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.emclient.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
+import org.springframework.cloud.netflix.feign.ribbon.FeignRibbonClientAutoConfiguration;
+import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import uk.gov.hmcts.reform.emclient.application.EvidenceManagementClientApplication;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(RootController.class)
+@ImportAutoConfiguration({RibbonAutoConfiguration.class,HttpMessageConvertersAutoConfiguration.class, FeignRibbonClientAutoConfiguration.class, FeignAutoConfiguration.class})
+@ContextConfiguration(classes = EvidenceManagementClientApplication.class)
+@AutoConfigureMockMvc
+public class RootControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void getShouldReturn200() throws Exception {
+
+        // given
+        MockHttpServletRequestBuilder getRequest = MockMvcRequestBuilders.get("/");
+
+        // when
+        ResultActions performedGet = mvc.perform(getRequest);
+
+        // then
+        performedGet.andExpect(status().isOk()).andReturn();
+    }
+}


### PR DESCRIPTION
# Description

Adds a Root Controller to EMCA so that Azure checks to '/' do not return a 404 and instead returns a 200 so we don't get any false positive errors.