### PR TITLE
DIV-3956 - reduced logging noise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,8 @@ def versions = [
         springRetry: '1.2.1.RELEASE',
         springBoot: '2.1.3.RELEASE',
         unirestJava: '1.4.9',
-        wiremockVersion: '2.8.0'
+        wiremockVersion: '2.8.0',
+        springSecurityCrypto: '5.1.5.RELEASE'
 ]
 
 dependencies {
@@ -199,6 +200,10 @@ dependencies {
     }
 
     compile (group:  'org.springframework.security', name: 'spring-security-rsa', version: versions.spring_security_rsa) {
+        force = true
+    }
+
+    compile (group:  'org.springframework.security', name: 'spring-security-crypto', version: versions.springSecurityCrypto) {
         force = true
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/emclient/EMClientFileUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/emclient/EMClientFileUploadTest.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
-import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
 import java.io.File;

--- a/src/main/java/uk/gov/hmcts/reform/emclient/config/HttpConnectionConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/config/HttpConnectionConfiguration.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.emclient.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -22,7 +20,6 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestIdSettingInterceptor;
-import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestLoggingInterceptor;
 
 import static java.util.Arrays.asList;
 
@@ -93,8 +90,6 @@ public class HttpConnectionConfiguration {
                 .create()
                 .useSystemProperties()
                 .addInterceptorFirst(new OutboundRequestIdSettingInterceptor())
-                .addInterceptorFirst((HttpRequestInterceptor) new OutboundRequestLoggingInterceptor())
-                .addInterceptorLast((HttpResponseInterceptor) new OutboundRequestLoggingInterceptor())
                 .setDefaultRequestConfig(config)
                 .build();
 

--- a/src/main/java/uk/gov/hmcts/reform/emclient/errorhandler/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/errorhandler/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.emclient.errorhandler;
 
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolationException;
 

--- a/src/test/java/uk/gov/hmcts/reform/emclient/health/WebServiceHealthCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/health/WebServiceHealthCheckTest.java
@@ -15,7 +15,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
# Description

It's causing more than 1 million log messages in production

https://github.com/hmcts/java-logging/blob/master/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptor.java#L41

Also reduced test loggin to WARN

Before:

![Screenshot 2019-04-05 at 17 06 49](https://user-images.githubusercontent.com/629600/55712665-11a73900-59e7-11e9-8347-c0859dc1ce60.png)

After:

<img width="1422" alt="Screenshot 2019-04-08 at 10 15 48" src="https://user-images.githubusercontent.com/629600/55712809-516e2080-59e7-11e9-9db8-637b7c36d4f1.png">


Fixes #DIV-3956

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
