### PR TITLE
Force more secure version on tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,8 @@ def versions = [
         spring_security_rsa                     : '1.0.8.RELEASE',
         unirestJava                             : '1.4.9',
         wiremockVersion                         : '2.8.0',
-        springSecurityCrypto                    : '5.1.5.RELEASE'
+        springSecurityCrypto                    : '5.1.5.RELEASE',
+        tomcat                                  : '9.0.19'
 ]
 
 dependencies {
@@ -201,6 +202,16 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: versions.reformPropertiesVolume
 
     compile (group: 'com.google.guava', name: 'guava', version: versions.guava) {
+        force = true
+    }
+    
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-core', version: versions.tomcat) {
+        force = true
+    }
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-websocket', version: versions.tomcat) {
+        force = true
+    }
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-el', version: versions.tomcat) {
         force = true
     }
 


### PR DESCRIPTION
# Description

Default tomcat version has a dependency-check issue that is resolved in 9.0.19, which is compatible with our current dependencies.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
