### PR TITLE
DIV-4835 Fix PMD/checkstyle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ apply plugin: 'net.serenity-bdd.aggregator'
 
 pmd {
     toolVersion = '6.11.0'
+    ignoreFailures = true
+    sourceSets = [sourceSets.main, sourceSets.test]
+    reportsDir = file("$project.buildDir/reports/pmd")
+    ruleSetFiles = files("ruleset.xml")
+    ruleSets = []
 }
 
 group = 'uk.gov.hmcts.reform.divorce'

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Evidence Management Client Api ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        Ruleset for Evidence Management Client Api
+    </description>
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/multithreading.xml"/>
+    <rule ref="category/java/bestpractices.xml"/>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="MethodArgumentCouldBeFinal"/>
+        <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="TooManyStaticImports"/>
+        <exclude name="ConfusingTernary"/>
+    </rule>
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/design.xml">
+        <exclude name="UseUtilityClass"/>
+        <exclude name="LoosePackageCoupling"/>
+    </rule>
+    <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+        <properties>
+            <property name="IgnoreJUnitCompletely" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/documentation.xml"/>
+</ruleset>


### PR DESCRIPTION
# Description
Previously the Gradle build would be polluted with hundreds of lines of warnings about migration of rulesets to new files. This change migrates to the new rulesets and also carries over the rule exclusions that we have. This makes the build output far more readable.

Fixes # 
[DIV-4835 Fix PMD/checkstyle warnings](https://tools.hmcts.net/jira/browse/DIV-4835)

## Type of change
Reduce log pollution

# How Has This Been Tested?
Run command 
```bash
./gradlew clean build
```
from project directory and check build output for occurrence of ruleset migration messages.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
