### PR TITLE
DIV-5762 - use java chart v2.6.0 and reduced duplicated env references

### DIFF
--- a/charts/div-emca/Chart.yaml
+++ b/charts/div-emca/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Evidence Management Client Api
 name: div-emca
-version: 1.1.0
+version: 1.2.0

--- a/charts/div-emca/requirements.yaml
+++ b/charts/div-emca/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.3.1
+    version: ~2.6.0
     repository: "@hmctspublic"

--- a/charts/div-emca/values.aat.template.yaml
+++ b/charts/div-emca/values.aat.template.yaml
@@ -1,13 +1,7 @@
 java:
   environment:
-    AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-    DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
-    ENVIRONMENT_NAME: "aat"
-    EVIDENCE_MANAGEMENT_HEALTH_URL: "http://dm-store-aat.service.core-compute-aat.internal/health"
-    EVIDENCE_MANAGEMENT_UPLOAD_FILE_URL: "http://dm-store-aat.service.core-compute-aat.internal/documents"
     IDAM_API_HEALTH_URI: "https://idam-api.aat.platform.hmcts.net/health"
     IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"
-    REFORM_ENVIRONMENT: "aat"
 
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/charts/div-emca/values.preview.template.yaml
+++ b/charts/div-emca/values.preview.template.yaml
@@ -1,13 +1,7 @@
 java:
   environment:
-    AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-    DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
-    ENVIRONMENT_NAME: "aat"
-    EVIDENCE_MANAGEMENT_HEALTH_URL: "http://dm-store-aat.service.core-compute-aat.internal/health"
-    EVIDENCE_MANAGEMENT_UPLOAD_FILE_URL: "http://dm-store-aat.service.core-compute-aat.internal/documents"
     IDAM_API_HEALTH_URI: "https://idam-api.aat.platform.hmcts.net/health"
     IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"
-    REFORM_ENVIRONMENT: "aat"
 
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/charts/div-emca/values.yaml
+++ b/charts/div-emca/values.yaml
@@ -1,8 +1,10 @@
 java:
   applicationPort: 4006
   environment:
-    REFORM_TEAM: "div"
-    REFORM_SERVICE_NAME: "emca"
+    AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    EVIDENCE_MANAGEMENT_HEALTH_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/health"
+    EVIDENCE_MANAGEMENT_UPLOAD_FILE_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/documents"
     AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: "divorce_document_generator"
     AUTH_PROVIDER_SERVICE_CLIENT_TOKENTIMETOLIVEINSECONDS: "900"
     HTTP_CONNECT_REQUEST_TIMEOUT: "60000"

--- a/charts/div-emca/values.yaml
+++ b/charts/div-emca/values.yaml
@@ -1,5 +1,6 @@
 java:
   applicationPort: 4006
+  ingressHost: "div-emca-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
   environment:
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"


### PR DESCRIPTION
# Description

Reduced duplicated config values by moving them to values.yaml
And using {{ .Values.global.environment }} placeholder
Also removed unused env variables (if any)

See 
* https://github.com/hmcts/chart-java/pull/61 
* https://hmcts-reform.slack.com/archives/CLE7A3SKV/p1568286603003800

Fixes #DIV-5762

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

