### PR TITLE
FIX-Address CVE-2020-5398 and upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 buildscript {
+    ext {
+        springBootVersion = '2.2.4.RELEASE'
+    }
     repositories {
         mavenLocal()
         mavenCentral()
@@ -9,73 +12,62 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath('info.solidsoft.gradle.pitest:gradle-pitest-plugin:0.32.0') {
+        classpath('info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.6') {
             exclude(group: 'org.pitest')
         }
-        classpath('org.pitest:pitest-command-line:0.33')
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:versions.springBoot")
-        classpath("net.serenity-bdd:serenity-gradle-plugin:2.0.41")
+        classpath('org.pitest:pitest-command-line:1.4.11')
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath("net.serenity-bdd:serenity-gradle-plugin:2.1.2")
     }
 }
 
 plugins {
     id 'application'
-    id 'io.spring.dependency-management' version '1.0.3.RELEASE'
-    id 'info.solidsoft.pitest' version '1.3.0'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '5.2.2'
-    id 'org.sonarqube' version '2.7'
-    id 'org.springframework.boot' version '2.1.3.RELEASE'
-    id 'pmd'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'info.solidsoft.pitest' version '1.4.6'
+    id 'org.owasp.dependencycheck' version '5.3.0'
+    id 'org.sonarqube' version '2.8'
+    id 'org.springframework.boot' version '2.2.4.RELEASE'
 }
 
 def versions = [
-        commonsIo                               : '2.5',
-        commonsLang3                            : '3.0',
-        guava                                   : '27.0.1-jre',
+        commonsIo                               : '2.6',
+        commonsLang3                            : '3.9',
+        guava                                   : '28.2-jre',
         hibernate                               : '6.0.17.Final',
-        jacksonCore                             : '2.10.0',
-        jacksonDatabind                         : '2.10.0',
+        jacksonCore                             : '2.10.2',
+        jacksonDatabind                         : '2.10.2',
         javaxValidation                         : '2.0.0.Final',
-        jaywayJsonPath                          : '2.2.0',
+        jaywayJsonPath                          : '2.4.0',
         jsr305                                  : '3.0.2',
-        junit                                   : '4.12',
-        lombok                                  : '1.16.16',
-        puppyCrawl                              : '8.21',
+        junit                                   : '4.13',
+        lombok                                  : '1.18.10',
+        puppyCrawl                              : '8.29',
         reformHealth                            : '0.0.5',
         reformPropertiesVolume                  : '0.0.4',
-        reformsHttpProxySpringBootAutoconfigure : '1.1.0',
+        reformSpringBootAutoConfigure           : '2.0.0',
         reformsJavaLogging                      : '5.1.1',
         restAssured                             : '3.3.0',
-        serenity                                : '2.0.41',
-        serenityCucumber                        : '1.9.31',
+        serenity                                : '2.1.2',
+        serenityCucumber                        : '1.9.51',
         serviceTokenGenerator                   : '3.0.0',
         skyscreamer                             : '1.2.3',
-        springBoot                              : '2.1.3.RELEASE',
-        springCloud                             : '2.1.1.RELEASE',
+        springBoot                              : '2.2.4.RELEASE',
+        springCloud                             : '2.2.1.RELEASE',
         springfoxSwagger                        : '2.9.2',
-        springHateoas                           : '0.25.1.RELEASE',
+        springHateoas                           : '0.25.2.RELEASE',
         springPluginCore                        : '1.2.0.RELEASE',
-        springRetry                             : '1.2.4.RELEASE',
-        springSecurityCrypto                    : '5.2.0.RELEASE',
+        springRetry                             : '1.2.5.RELEASE',
+        springSecurityCrypto                    : '5.2.1.RELEASE',
         spring_security_rsa                     : '1.0.8.RELEASE',
         tomcat                                  : '9.0.30',
         unirestJava                             : '1.4.9',
-        wiremockVersion                         : '2.8.0'
+        wiremockVersion                         : '2.25.1'
 ]
 
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'net.serenity-bdd.aggregator'
-
-pmd {
-    toolVersion = '6.13.0'
-    ignoreFailures = true
-    sourceSets = [sourceSets.main, sourceSets.test]
-    reportsDir = file("$project.buildDir/reports/pmd")
-    ruleSetFiles = files("ruleset.xml")
-    ruleSets = []
-    incrementalAnalysis = true
-}
 
 group = 'uk.gov.hmcts.reform.divorce'
 version = '3.0.0'
@@ -207,7 +199,7 @@ dependencies {
     compile group: 'org.springframework.retry', name: 'spring-retry', version: versions.springRetry
 
     compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: versions.reformHealth
-    compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformsHttpProxySpringBootAutoconfigure
+    compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
     compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformsJavaLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformsJavaLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformsJavaLogging
@@ -292,6 +284,28 @@ task developAddReleaseSuffix() {
     version = "${version}-SNAPSHOT"
 }
 
+jacocoTestReport {
+    executionData(test)
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.9
+            }
+        }
+    }
+}
+
+project.tasks['sonarqube'].dependsOn jacocoTestReport
+
 def sonarExclusions = [
         '**uk/gov/hmcts/reform/emclient/exception/*',
         '**uk/gov/hmcts/reform/emclient/configuration/*',
@@ -305,38 +319,16 @@ sonarqube {
     properties {
         property "sonar.projectKey", "DivorceEvidenceManagementClientApi"
         property "sonar.projectName", "Divorce :: Evidence Management Client API"
-        property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
-        property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/functional.exec"
         property "sonar.exclusions", sonarExclusions.join(", ")
+        property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
+        property "sonar.pitest.mode", "reuseReport"
+        property "sonar.pitest.reportsDirectory", "build/reports/pitest"
+
     }
 }
 
 task addReleaseSuffixToDevelop() {
     version = "${version}-SNAPSHOT"
-}
-
-jacocoTestReport {
-    executionData(test, functional)
-
-    reports {
-        xml {
-            enabled true
-        }
-
-        html {
-            enabled true
-        }
-    }
-}
-
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.9
-            }
-        }
-    }
 }
 
 def debug = System.getProperty("debug")

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -26,13 +26,4 @@
         <cve>CVE-2015-2156</cve>
         <cve>CVE-2019-16869</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-           Spring update to 2.2.4.RELEASE causing failures in all health check
-           tests due to missing properties and possible incorrect configuration.
-           Potential solutions were investigated in PR #691 ]]>
-        </notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2020-5398</cve>
-    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/emclient/config/HttpConnectionConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/config/HttpConnectionConfiguration.java
@@ -21,12 +21,17 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestIdSettingInterceptor;
 
+import java.nio.charset.Charset;
+
 import static java.util.Arrays.asList;
 
 @Configuration
 public class HttpConnectionConfiguration {
 
-    private static final MediaType MEDIA_TYPE_HAL_JSON = new MediaType("application", "vnd.uk.gov.hmcts.dm.document-collection.v1+hal+json", MappingJackson2HttpMessageConverter.DEFAULT_CHARSET);
+    private static final MediaType MEDIA_TYPE_HAL_JSON =
+        new MediaType("application",
+            "vnd.uk.gov.hmcts.dm.document-collection.v1+hal+json",
+            Charset.forName("UTF-8"));
 
     @Value("${http.connect.timeout}")
     private int httpConnectTimeout;


### PR DESCRIPTION
# Description

- Updated Spring and all other outdated packages - serenity, Jackson, pitest etc
  - The above removed the need for suppressing CVE-2020-5398
- Resolved NullPointerException in HttpConnectionConfiguration causing test failures owing to a now deprecated default charset in MappingJackson2HttpMessageConverter - new version of spring

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit and integration tests reran, ensured all failures are addressed

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
