### PR TITLE
DFR-3859: Update azurerm provider to v4.32.0

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.96.0"
+      version = "4.32.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DFR-3859

Bump azurerm due to deprecation warnings.
